### PR TITLE
Recolor "scroll-to-bottom" button

### DIFF
--- a/black-white.css
+++ b/black-white.css
@@ -184,6 +184,14 @@ input[readonly*='true']{
 .im-mess .im-mess--check {
   filter: saturate(0);
 }
+.im-navigation__button {
+    border-color: var(--color7);
+    background-color: var(--color7) !important;
+}
+
+.im-navigation--to-end .im-navigation__button{
+    background: var(--color6) url("data:image/svg+xml;charset=utf-8,%3Csvg%20height%3D%227%22%20viewBox%3D%220%200%2014%207%22%20width%3D%2214%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M1.64.232c-.424-.354-1.055-.296-1.408.128s-.296%201.055.128%201.408l6%205c.371.309.91.309%201.28%200l6-5c.424-.354.482-.984.128-1.408s-.984-.482-1.408-.128l-5.36%204.467z%22%20fill%3D%22%23888888%22%2F%3E%3C%2Fsvg%3E") center 17px no-repeat
+}
 .audio_page_player2 .audio_page_player_track_slider.slider.slider_size_1 .slider_slide{
   background-color:var(--color7)!important;
 }


### PR DESCRIPTION
In B&W theme "scroll-to-bottom" button stayed with white bg and light blue icon. I made this with dark bg and grey icon

**Before**
![Screenshot_20200521_161028](https://user-images.githubusercontent.com/51821039/82562427-daa9cd80-9b7d-11ea-9013-08d688774fb5.png)
**After**
![Screenshot_20200521_160916](https://user-images.githubusercontent.com/51821039/82562326-adf5b600-9b7d-11ea-8776-63e49d4420c4.png)

